### PR TITLE
Split dockerfiles for frontend and backend and fixed backend host 

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,22 @@
+FROM node:14
+
+# FROM ubuntu:20.04
+# RUN apt-get update && apt-get install -y curl
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 3000
+CMD [ "node", "crystal-api/server.js" ]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -19,4 +19,4 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "node", "crystal-api/server.js" ]
+CMD [ "npm", "run", "serve" ]

--- a/crystal-api/server.js
+++ b/crystal-api/server.js
@@ -5,7 +5,7 @@ const Routes = require('./controller');
 
 const init = async () => {
   const server = Hapi.Server({
-    host: `localhost`,
+    host: `0.0.0.0`,
     port: 3000,
   });
   server.route(Routes);


### PR DESCRIPTION
So so nodejs backend will listen on any hostname (to allow connections from outside the docker container)

Example docker build and run commands after this change, for reference:
```
docker build -t sammiicrystals-frontend -f Dockerfile.frontend .
docker build -t sammiicrystals-backend -f Dockerfile.backend .
```

```
docker run -d -p 80:8080 sammiicrystals-frontend
docker run -d -p 3000:3000 sammiicrystals-backend
```

You could then load the frontend locally at http://localhost
and load the API at http://localhost:3000